### PR TITLE
Update fhir converter to c6751a33

### DIFF
--- a/packages/fhir-converter/package-lock.json
+++ b/packages/fhir-converter/package-lock.json
@@ -47,7 +47,6 @@
         "jest": "^29.5.0",
         "nyc": "^14.1.1",
         "openapi-types": "^12.1.3",
-        "supertest": "^4.0.2",
         "validator": "^13.7.0"
       }
     },
@@ -2414,11 +2413,6 @@
         "debug": "^2.6.8"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3438,17 +3432,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "6.2.0",
       "license": "MIT",
@@ -3461,14 +3444,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3534,11 +3509,6 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "license": "MIT"
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -3817,14 +3787,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -4923,11 +4885,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5226,28 +5183,6 @@
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "1.2.6",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -10928,52 +10863,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
-    },
-    "node_modules/superagent": {
-      "version": "3.8.3",
-      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/superagent/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/supertest": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "methods": "^1.1.2",
-        "superagent": "^3.8.3"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/packages/fhir-converter/package.json
+++ b/packages/fhir-converter/package.json
@@ -15,6 +15,7 @@
     "start": "node --experimental-worker src/index.js",
     "start-dev": "npm run dev",
     "start-docker-compose": "docker compose -f docker-compose.yml up",
+    "prep-deploy": "npm ci --no-fund",
     "eslint": "eslint src/**/*.js",
     "lint:hbs": "ember-template-lint src/templates/cda > lint-results.txt",
     "full-hbs-lint": "./full-hbs-lint.sh"
@@ -91,7 +92,6 @@
     "jest": "^29.5.0",
     "nyc": "^14.1.1",
     "openapi-types": "^12.1.3",
-    "supertest": "^4.0.2",
     "validator": "^13.7.0"
   },
   "dependencies": {

--- a/packages/fhir-converter/src/lib/cda/cda.js
+++ b/packages/fhir-converter/src/lib/cda/cda.js
@@ -29,13 +29,12 @@ let dataHandler = require("../dataHandler/dataHandler");
 let minifyXML = require("minify-xml");
 const { XMLParser } = require("fast-xml-parser");
 
-
 const elementTime00010101Regex = new RegExp('<time value="00010101000000+0000"s*/>', "g");
 const elementTime00010101Replacement = "";
 const valueTime00010101Regex = new RegExp('value="00010101000000*"s*/>', "g");
 const valueTime00010101Replacement = 'nullFlavor="NI" />';
 
-const ampersandRegex = new RegExp('&(?!(?:#\\d+|#x[\\da-fA-F]+|amp|lt|gt|quot|apos);)', 'g');
+const ampersandRegex = new RegExp("&(?!(?:#\\d+|#x[\\da-fA-F]+|amp|lt|gt|quot|apos);)", "g");
 
 module.exports = class cda extends dataHandler {
   constructor() {
@@ -67,7 +66,7 @@ module.exports = class cda extends dataHandler {
   }
 
   removeLineBreaks(text) {
-    return text.replace(/(\r\n|\n|\r)/gm, " ");
+    return text == undefined ? "" : String(text).replace(/(\r\n|\n|\r)/gm, " ");
   }
 
   findAndReplacePropsWithIdValue(obj, propNames) {
@@ -83,7 +82,7 @@ module.exports = class cda extends dataHandler {
 
           if (existingIsB64) {
             // if we already have a b64 string, just use it, as the reference will be a dup
-            obj[key] = { _b64: this.removeLineBreaks(existingText) };
+            obj[key] = { _b64: existingText };
           }
           // we found the prop, change it's value to the reference text
           else if (value.reference && value.reference.value) {
@@ -92,7 +91,7 @@ module.exports = class cda extends dataHandler {
             const foundB64 = this.idToB64ValueMap[id];
             if (foundB64) {
               // if we found b64, just use it, we shouldn't mix this with any existing text
-              obj[key] = { _b64: this.removeLineBreaks(foundB64) };
+              obj[key] = { _b64: foundB64 };
             } else if (foundText) {
               const newText =
                 existingText && existingText !== foundText
@@ -142,12 +141,12 @@ module.exports = class cda extends dataHandler {
       }
       let minifiedData = minifyXML.minify(data, {
         removeComments: true,
-        removeWhitespaceBetweenTags: true,
+        removeWhitespaceBetweenTags: false, // Keep whitespace between tags to preserve spacing in text nodes
         considerPreserveWhitespace: true,
         collapseWhitespaceInTags: true,
         collapseEmptyElements: true,
-        trimWhitespaceFromTexts: true,
-        collapseWhitespaceInTexts: true, // this fixes the newline problem, but then doctor's notes look bad
+        trimWhitespaceFromTexts: false, // Don't trim - preserves formatting
+        collapseWhitespaceInTexts: false, // Don't collapse - preserves line breaks and spacing
         collapseWhitespaceInProlog: true,
         collapseWhitespaceInDocType: true,
         removeUnusedNamespaces: true,

--- a/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/packages/fhir-converter/src/lib/handlebars-converter/handlebars-helpers.js
@@ -203,7 +203,19 @@ var generateLocationId = function (location) {
     );
     return id;
   } else if (location.playingEntity?.name) {
-    const id = uuidv3(location.playingEntity.name, uuidv3.URL);
+    /**
+     * In some cases we see playingEntity?.name that looks like name: { _: 'REAL NAME' } which fails conversion.
+     * We're adding this because name is supposed to be a string ('REAL NAME').
+     * This has something to do with wether "addr" is present in playingEntity when it is not we seem to be hitting this error.
+     * The exact cause is unknown.
+     *
+     * Link to original issue: https://linear.app/metriport/issue/ENG-975/fhir-converter-name-field-not-working
+     */
+    const peName = location?.playingEntity?.name;
+    if (peName && typeof peName === "object" && Object.prototype.hasOwnProperty.call(peName, "_")) {
+      return uuidv3(peName._, uuidv3.URL);
+    }
+    const id = uuidv3(peName, uuidv3.URL);
     return id;
   }
 
@@ -341,7 +353,7 @@ var buildCodeableConcept = function (code, canBeUnknown = false) {
 
   const codeableConcept = {
     text,
-    coding: buildCoding(code, canBeUnknown),
+    coding: [buildCoding(code, canBeUnknown)],
   };
 
   return codeableConcept;
@@ -672,6 +684,27 @@ var getSpecifiedEntryRelationship = function (entryRelationshipContainer, target
     entryRelationship =>
       entryRelationship?.typeCode && entryRelationship.typeCode === targetTypeCode
   );
+};
+
+var getSpecifiedEntryRelationshipArray = function (entryRelationshipContainer, targetTypeCode) {
+  const entryRelationshipArray = Array.isArray(entryRelationshipContainer)
+    ? entryRelationshipContainer
+    : [entryRelationshipContainer];
+
+  return entryRelationshipArray?.filter(er => er?.typeCode && er.typeCode === targetTypeCode);
+};
+
+var generateUuid = function (urlNamespace) {
+  return uuidv3("".concat(urlNamespace), uuidv3.URL);
+};
+
+var buildMedicationRequestId = function (substanceAdminEntries) {
+  const supplyEntry = getSpecifiedEntryRelationshipArray(substanceAdminEntries, "REFR").find(
+    er => er.supply
+  );
+  if (!supplyEntry) return undefined;
+  const uuid = generateUuid(JSON.stringify(supplyEntry.supply));
+  return uuid;
 };
 
 module.exports.internal = {
@@ -1351,7 +1384,7 @@ module.exports.external = [
     name: "generateUUID",
     description: "Generates a guid based on a URL: generateUUID url",
     func: function (urlNamespace) {
-      return uuidv3("".concat(urlNamespace), uuidv3.URL);
+      return generateUuid(urlNamespace);
     },
   },
   {
@@ -1428,6 +1461,7 @@ module.exports.external = [
     name: "toString",
     description: "Converts to string: toString object",
     func: function (str) {
+      if (str == undefined) return "";
       return str.toString();
     },
   },
@@ -1618,7 +1652,7 @@ module.exports.external = [
     name: "startsWith",
     description: "Checks if a string starts with a given substring: startsWith string substring",
     func: function (str, substr) {
-      return str.startsWith(substr);
+      return String(str)?.startsWith(substr);
     },
   },
   {
@@ -2015,6 +2049,7 @@ module.exports.external = [
       if (!mappedData || mappedData.length === 0) return "";
       return mappedData
         .map(entry => {
+          if (!entry || typeof entry !== "object") return "";
           return Object.entries(entry)
             .map(([key, value]) => `${key}: ${value}`)
             .join("\n");
@@ -2103,6 +2138,21 @@ module.exports.external = [
     description: "Returns the specified entry relationship if it exists.",
     func: function (entryRelationships, targetTypeCode) {
       return getSpecifiedEntryRelationship(entryRelationships, targetTypeCode);
+    },
+  },
+  {
+    name: "getSpecifiedEntryRelationshipArray",
+    description: "Returns an array of specified entry relationships.",
+    func: function (entryRelationships, targetTypeCode) {
+      return getSpecifiedEntryRelationshipArray(entryRelationships, targetTypeCode);
+    },
+  },
+  {
+    name: "buildMedicationRequestId",
+    description:
+      "Builds a medication request ID from a list of entry relationships that contain a supply field.",
+    func: function (substanceAdminEntries) {
+      return buildMedicationRequestId(substanceAdminEntries);
     },
   },
 ];

--- a/packages/fhir-converter/src/lib/workers/worker.js
+++ b/packages/fhir-converter/src/lib/workers/worker.js
@@ -69,16 +69,22 @@ function generateResult(
   template,
   patientId,
   encounterTimePeriod,
-  encompassingEncounterIds
+  encompassingEncounterIds,
+  isDebug
 ) {
-  var result = dataTypeHandler.postProcessResult(
-    template(dataContext, {
-      data: { metriportPatientId: patientId, encounterTimePeriod, encompassingEncounterIds },
-    })
-  );
-  return Object.assign(dataTypeHandler.getConversionResultMetadata(dataContext.msg), {
-    fhirResource: result,
-  });
+  try {
+    var result = dataTypeHandler.postProcessResult(
+      template(dataContext, {
+        data: { metriportPatientId: patientId, encounterTimePeriod, encompassingEncounterIds },
+      })
+    );
+    return Object.assign(dataTypeHandler.getConversionResultMetadata(dataContext.msg), {
+      fhirResource: result,
+    });
+  } catch (err) {
+    if (isDebug) console.log(`[patient ${patientId}] DEBUG Error: ${err?.message}`, err?.stack);
+    throw err;
+  }
 }
 
 WorkerUtils.workerTaskProcessor(msg => {
@@ -87,139 +93,186 @@ WorkerUtils.workerTaskProcessor(msg => {
       const startTime = new Date().getTime();
       const nowIso = new Date().toISOString();
       const getDuration = () => new Date().getTime() - startTime;
-      switch (msg.type) {
-        case "/api/convert/:srcDataType/:template":
-          {
-            let srcData = msg.srcData;
-            let templateName = msg.templateName;
-            let srcDataType = msg.srcDataType;
-            let patientId = msg.patientId;
-            let fileName = msg.fileName;
 
-            console.log(`[patient ${patientId}] Processing file ${fileName} at ${nowIso}`);
+      // Cleanup function to ensure session state is reset
+      const cleanup = () => {
+        try {
+          session.set(constants.CLS_KEY_HANDLEBAR_INSTANCE, null);
+          session.set(constants.CLS_KEY_TEMPLATE_LOCATION, null);
+        } catch (cleanupErr) {
+          console.error(`[worker] Error during cleanup: ${cleanupErr.message}`);
+        }
+      };
 
-            let encounterTimePeriod = extractEncounterTimePeriod(srcData);
-            let dataTypeHandler = dataHandlerFactory.createDataHandler(srcDataType);
-            let handlebarInstance = GetHandlebarsInstance(dataTypeHandler);
-            let encompassingEncounterIds = getEncompassingEncounterId(srcData);
-            session.set(constants.CLS_KEY_HANDLEBAR_INSTANCE, handlebarInstance);
-            session.set(
-              constants.CLS_KEY_TEMPLATE_LOCATION,
-              path.join(constants.TEMPLATE_FILES_LOCATION, dataTypeHandler.dataType)
-            );
+      try {
+        switch (msg.type) {
+          case "/api/convert/:srcDataType/:template":
+            {
+              let srcData = msg.srcData;
+              let templateName = msg.templateName;
+              let srcDataType = msg.srcDataType;
+              let patientId = msg.patientId;
+              let fileName = msg.fileName;
+              const isDebug = msg.isDebug;
 
-            if (!srcData || srcData.length == 0) {
-              reject({
-                status: 400,
-                resultMsg: errorMessage(errorCodes.BadRequest, "No srcData provided."),
-                duration: getDuration(),
-              });
-            }
+              console.log(`[patient ${patientId}] Processing file ${fileName} at ${nowIso}`);
 
-            const getTemplate = templateName => {
-              return new Promise((fulfill, reject) => {
-                var template = compileCache.get(templateName);
-                if (!template) {
-                  fs.readFile(
-                    path.join(constants.TEMPLATE_FILES_LOCATION, srcDataType, templateName),
-                    (err, templateContent) => {
-                      if (err) {
-                        reject({
-                          status: 404,
-                          resultMsg: errorMessage(errorCodes.NotFound, "Template not found"),
-                          duration: getDuration(),
-                        });
-                      } else {
-                        try {
-                          template = handlebarInstance.compile(
-                            dataTypeHandler.preProcessTemplate(templateContent.toString())
-                          );
-                          compileCache.put(templateName, template);
-                          fulfill(template);
-                        } catch (convertErr) {
-                          reject({
-                            status: 400,
-                            resultMsg: errorMessage(
-                              errorCodes.BadRequest,
-                              "Error during template compilation. " + convertErr.toString()
-                            ),
-                            duration: getDuration(),
-                          });
-                        }
-                      }
-                    }
-                  );
-                } else {
-                  fulfill(template);
-                }
-              });
-            };
+              let encounterTimePeriod = extractEncounterTimePeriod(srcData);
+              let dataTypeHandler = dataHandlerFactory.createDataHandler(srcDataType);
+              let handlebarInstance = GetHandlebarsInstance(dataTypeHandler);
+              let encompassingEncounterIds = getEncompassingEncounterId(srcData);
+              session.set(constants.CLS_KEY_HANDLEBAR_INSTANCE, handlebarInstance);
+              session.set(
+                constants.CLS_KEY_TEMPLATE_LOCATION,
+                path.join(constants.TEMPLATE_FILES_LOCATION, dataTypeHandler.dataType)
+              );
 
-            dataTypeHandler
-              .parseSrcData(srcData)
-              .then(parsedData => {
-                var dataContext = {
-                  msg: parsedData,
-                };
-                // console.log(dataContext);
-                getTemplate(templateName).then(
-                  compiledTemplate => {
-                    try {
-                      fulfill({
-                        status: 200,
-                        resultMsg: generateResult(
-                          dataTypeHandler,
-                          dataContext,
-                          compiledTemplate,
-                          patientId,
-                          encounterTimePeriod,
-                          encompassingEncounterIds
-                        ),
-                        duration: getDuration(),
-                      });
-                    } catch (convertErr) {
-                      reject({
-                        status: 400,
-                        resultMsg: errorMessage(
-                          errorCodes.BadRequest,
-                          "Error during template evaluation. " + convertErr.toString()
-                        ),
-                        duration: getDuration(),
-                      });
-                    }
-                  },
-                  err => {
-                    reject(err);
-                  }
-                );
-              })
-              .catch(err => {
+              if (!srcData || srcData.length == 0) {
+                cleanup();
                 reject({
                   status: 400,
-                  resultMsg: errorMessage(
-                    errorCodes.BadRequest,
-                    `Unable to parse input data for template ${templateName}. ${err.toString()}`
-                  ),
+                  resultMsg: errorMessage(errorCodes.BadRequest, "No srcData provided."),
                   duration: getDuration(),
                 });
-              });
-          }
-          break;
+                return;
+              }
 
-        case "templatesUpdated":
-          {
-            expireCache();
-            fulfill();
-          }
-          break;
+              const getTemplate = templateName => {
+                return new Promise((fulfill, reject) => {
+                  var template = compileCache.get(templateName);
+                  if (!template) {
+                    fs.readFile(
+                      path.join(constants.TEMPLATE_FILES_LOCATION, srcDataType, templateName),
+                      (err, templateContent) => {
+                        if (err) {
+                          reject({
+                            status: 404,
+                            resultMsg: errorMessage(errorCodes.NotFound, "Template not found"),
+                            duration: getDuration(),
+                          });
+                        } else {
+                          try {
+                            template = handlebarInstance.compile(
+                              dataTypeHandler.preProcessTemplate(templateContent.toString())
+                            );
+                            compileCache.put(templateName, template);
+                            fulfill(template);
+                          } catch (convertErr) {
+                            reject({
+                              status: 400,
+                              resultMsg: errorMessage(
+                                errorCodes.BadRequest,
+                                "Error during template compilation. " + convertErr.toString()
+                              ),
+                              duration: getDuration(),
+                            });
+                          }
+                        }
+                      }
+                    );
+                  } else {
+                    fulfill(template);
+                  }
+                });
+              };
 
-        case "constantsUpdated":
-          {
-            constants = JSON.parse(msg.data);
-            expireCache();
-            fulfill();
-          }
-          break;
+              dataTypeHandler
+                .parseSrcData(srcData)
+                .then(parsedData => {
+                  var dataContext = {
+                    msg: parsedData,
+                  };
+                  // console.log(dataContext);
+                  getTemplate(templateName).then(
+                    compiledTemplate => {
+                      try {
+                        fulfill({
+                          status: 200,
+                          resultMsg: generateResult(
+                            dataTypeHandler,
+                            dataContext,
+                            compiledTemplate,
+                            patientId,
+                            encounterTimePeriod,
+                            encompassingEncounterIds,
+                            isDebug
+                          ),
+                          duration: getDuration(),
+                        });
+                      } catch (convertErr) {
+                        cleanup();
+                        reject({
+                          status: 400,
+                          resultMsg: errorMessage(
+                            errorCodes.BadRequest,
+                            "Error during template evaluation. " + convertErr.toString()
+                          ),
+                          duration: getDuration(),
+                        });
+                      }
+                    },
+                    err => {
+                      cleanup();
+                      reject(err);
+                    }
+                  );
+                })
+                .catch(err => {
+                  cleanup();
+                  console.error(
+                    `Error parsing input data for template ${templateName}: ${err.toString()}, fileName: ${fileName}`
+                  );
+                  console.error(err.stack);
+                  reject({
+                    status: 400,
+                    resultMsg: errorMessage(
+                      errorCodes.BadRequest,
+                      `Unable to parse input data for template ${templateName}. ${err.toString()}`
+                    ),
+                    duration: getDuration(),
+                  });
+                });
+            }
+            break;
+
+          case "templatesUpdated":
+            {
+              expireCache();
+              fulfill();
+            }
+            break;
+
+          case "constantsUpdated":
+            {
+              constants = JSON.parse(msg.data);
+              expireCache();
+              fulfill();
+            }
+            break;
+
+          default:
+            cleanup();
+            reject({
+              status: 400,
+              resultMsg: errorMessage(errorCodes.BadRequest, `Unknown message type: ${msg.type}`),
+              duration: getDuration(),
+            });
+        }
+      } catch (unhandledError) {
+        cleanup();
+        console.error(
+          `[worker] Unhandled error in worker task processor: ${
+            unhandledError.stack ?? unhandledError.message ?? unhandledError
+          }`
+        );
+        reject({
+          status: 500,
+          resultMsg: errorMessage(
+            errorCodes.InternalServerError,
+            `Worker error: ${unhandledError.message}`
+          ),
+          duration: getDuration(),
+        });
       }
     });
   });

--- a/packages/fhir-converter/src/routes.js
+++ b/packages/fhir-converter/src/routes.js
@@ -38,6 +38,7 @@ var fileSystemCache = require("./lib/fsCache/cache");
 var ncp = require("ncp").ncp;
 
 module.exports = function (app) {
+  // Set to 1 on local to debug
   const amountOfWorkers = require("os").cpus().length;
   console.log(
     `Creating a pool of ${amountOfWorkers} workers (${require("os").cpus().length} vCPUs)`
@@ -206,6 +207,7 @@ module.exports = function (app) {
     const retInvalidAccess = req.query.invalidAccess == "true";
     const patientId = req.query.patientId;
     const fileName = req.query.fileName;
+    const isDebug = req.query.isDebug == "true";
     const startTime = new Date().getTime();
     console.log(`[patient ${patientId}] Got file ${fileName} at ${new Date().toISOString()}`);
     workerPool
@@ -216,6 +218,7 @@ module.exports = function (app) {
         templateName: req.params.template,
         patientId,
         fileName,
+        isDebug,
       })
       .then(result => {
         const internalDuration = result.duration;

--- a/packages/fhir-converter/src/templates/cda/Header.hbs
+++ b/packages/fhir-converter/src/templates/cda/Header.hbs
@@ -39,6 +39,9 @@
     {{#if document.componentOf.encompassingEncounter}}
         {{!-- do we want to include this? Kinda a duplicate of more rich data later in encounter section --}}
         {{>Resources/Encounter.hbs encounter=document.componentOf.encompassingEncounter ID=@encompassingEncounterIds.newId}},
+        {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+            {{>References/Encounter/subject.hbs ID=@encompassingEncounterIds.newId REF=(concat 'Patient/' patientId.Id)}},
+        {{/with}}
         
         {{#if document.componentOf.encompassingEncounter.responsibleParty.assignedEntity}}
             {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=document.componentOf.encompassingEncounter.responsibleParty.assignedEntity) as |practitionerId|}}

--- a/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
+++ b/packages/fhir-converter/src/templates/cda/References/DiagnosticReport/assessment.hbs
@@ -29,6 +29,8 @@
     "resource":{
         "resourceType": "DiagnosticReport",
         "id":"{{ID}}",
+        "code":{{>DataType/CodeableConcept.hbs code=diagReport.code text=diagReport.title._ canBeUnknown=true}},
+        "status":{{>ValueSet/DiagnosticReportStatus.hbs code=diagReport.statusCode.code}},
         "presentedForm": [
                 {
                     "contentType": "text/plain",

--- a/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Observation.hbs
@@ -80,6 +80,14 @@
                     "valueQuantity": {{>DataType/Quantity.hbs quantity=../observationEntry.value}},
                 {{/if}}
             {{/with}}
+        {{else if (and observationEntry.value.low.value observationEntry.value.high.value) }}
+            {{#if (and observationEntry.value.low.value observationEntry.value.high.value) }}
+                "valueRange": {{>DataType/Range.hbs range=observationEntry.value}},
+            {{else if observationEntry.value.low.value}}
+                "valueQuantity": {{>DataType/Quantity.hbs quantity=observationEntry.value.low}},
+            {{else if observationEntry.value.high.value}}
+                "valueQuantity": {{>DataType/Quantity.hbs quantity=observationEntry.value.high}},
+            {{/if}}
         {{else if observationEntry.value._}}
             "valueString":"{{{parseReferenceData observationEntry.value._}}}",
         {{!-- in some cases text is here in the b64 field. Adding so no data loss but not sure if thats the way its supposed to be. also how it renders I do not know      --}}
@@ -89,7 +97,7 @@
             {{#if observationEntry.value.translation.originalText._}}
                 "valueString":"{{observationEntry.value.translation.value}} {{observationEntry.value.translation.originalText._}}"
             {{else}}
-                "valueString":"{{observationEntry.value.translation.value}}
+                "valueString":"{{observationEntry.value.translation.value}}"
             {{/if}}
         {{/if}}
         

--- a/packages/fhir-converter/src/templates/cda/Resources/Procedure.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/Procedure.hbs
@@ -43,11 +43,13 @@
         "status":{{>ValueSet/EventStatus.hbs code=procedureEntry.statusCode.code}},
         "code":{{>DataType/CodeableConcept.hbs code=procedureEntry.code}},
         {{#if procedureEntry.entryRelationship}}
-            "reasonCode": [
-                {{#each (toArray procedureEntry.entryRelationship)}}
-                    {{>DataType/CodeableConcept.hbs code=this.observation.value}},
-                {{/each}}
-            ],
+            {{#with (getSpecifiedEntryRelationshipArray procedureEntry.entryRelationship "RSON") as |reasonEntries|}}
+                "reasonCode": [
+                    {{#each reasonEntries as |reasonEntry|}}
+                        {{>DataType/CodeableConcept.hbs text=reasonEntry.observation.text._ code=reasonEntry.observation.value}},
+                    {{/each}}
+                ],                
+            {{/with}}
         {{/if}}
         {{#if procedureEntry.effectiveTime.value}}
             "performedDateTime":"{{formatAsDateTime procedureEntry.effectiveTime.value}}",

--- a/packages/fhir-converter/src/templates/cda/Resources/ServiceRequest.hbs
+++ b/packages/fhir-converter/src/templates/cda/Resources/ServiceRequest.hbs
@@ -37,6 +37,7 @@
             {{/each}}
         ],
         "status":{{>ValueSet/RequestStatus.hbs code=serviceEntry.statusCode.code}},
+        "intent": "original-order",
         "code":{{>DataType/CodeableConcept.hbs code=serviceEntry.code}},   
         "priority":"{{serviceEntry.priorityCode.displayName}}",
         "occuranceDateTime":"{{formatAsDateTime serviceEntry.effectiveTime.value}}",

--- a/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Assessments.hbs
@@ -30,7 +30,7 @@
         {{#each (toArray 2_16_840_1_113883_10_20_22_2_8) as |assessment|}}
             {{#if (and assessment.text (contains (toLower assessment.title._) "assessment"))}}
                 {{#with (extractAndMapTableData assessment.text) as |assessmentMap|}}
-                    {{>References/DiagnosticReport/assessment.hbs text=(convertMappedDataToPlainText assessmentMap) ID=(generateUUID (toJsonString assessment))}},
+                    {{>References/DiagnosticReport/assessment.hbs text=(convertMappedDataToPlainText assessmentMap) diagReport=assessment ID=(generateUUID (toJsonString assessment))}},
                 {{/with}}
             {{/if}}
         {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/CarePlan.hbs
@@ -31,6 +31,9 @@
                 {{!-- typeCode "REFR" -> priority for the encounter --}}
                 {{#with (getSpecifiedEntryRelationship careplanEntry.encounter.entryRelationship "RSON") as |conditionEntry|}}
                     {{>Resources/Condition.hbs conditionEntry=conditionEntry.observation ID=(generateUUID (toJsonString conditionEntry.observation))}},
+                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+	                    {{>References/Condition/subject.hbs ID=(generateUUID (toJsonString conditionEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
+                    {{/with}}
                     {{>References/CarePlan/addresses.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Condition/' (generateUUID (toJsonString conditionEntry.observation)))}}
                 {{/with}}
                 
@@ -62,6 +65,9 @@
                 {{!-- typeCode "REFR" -> priority for the encounter --}}
                 {{#with (getSpecifiedEntryRelationship careplanEntry.observation.entryRelationship "RSON") as |conditionEntry|}}
                     {{>Resources/Condition.hbs conditionEntry=conditionEntry.observation ID=(generateUUID (toJsonString conditionEntry.observation))}},
+                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+	                    {{>References/Condition/subject.hbs ID=(generateUUID (toJsonString conditionEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
+                    {{/with}}
                     {{>References/CarePlan/addresses.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Condition/' (generateUUID (toJsonString conditionEntry.observation)))}}
                 {{/with}}
                 {{!-- typeCode "SUBJ" -> instructions for the encounter --}}
@@ -94,6 +100,9 @@
                 {{!-- typeCode "REFR" -> priority for the encounter --}}
                 {{#with (getSpecifiedEntryRelationship careplanEntry.procedure.entryRelationship "RSON") as |conditionEntry|}}
                     {{>Resources/Condition.hbs conditionEntry=conditionEntry.observation ID=(generateUUID (toJsonString conditionEntry.observation))}},
+                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+	                    {{>References/Condition/subject.hbs ID=(generateUUID (toJsonString conditionEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
+                    {{/with}}
                     {{>References/CarePlan/addresses.hbs ID=(generateUUID (toJsonString careplanEntry)) REF=(concat 'Condition/' (generateUUID (toJsonString conditionEntry.observation)))}}
                 {{/with}}
                 {{!-- typeCode "SUBJ" -> instructions for the encounter --}}

--- a/packages/fhir-converter/src/templates/cda/Sections/HealthConcerns.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/HealthConcerns.hbs
@@ -35,6 +35,9 @@
                 {{/with}}
             {{else if healthEntry.observation.value.value}}
                 {{>Resources/Observation.hbs observationCategory="survey" observationEntry=healthEntry.observation ID=(generateUUID (toJsonString healthEntry.observation))}},
+                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                    {{>References/Observation/subject.hbs ID=(generateUUID (toJsonString healthEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
+                {{/with}}
             {{/if}}
         {{/each}}
     {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Medication.hbs
@@ -38,40 +38,47 @@
                         {{/with}}
                         
                         {{>References/MedicationStatement/medicationReference.hbs ID=(generateUUID (toJsonString medEntry.substanceAdministration)) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial)))}},
-                        {{#each (toArray medEntry.substanceAdministration.entryRelationship) as |medReq|}}
-                            {{#if medReq.supply}}   
-                                {{>Resources/MedicationRequest.hbs medicationRequest=medReq.supply date=medEntry.substanceAdministration.effectiveTime ID=(generateUUID (toJsonString medReq.supply))}},
-                                {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
-                                	{{>References/MedicationRequest/subject.hbs ID=(generateUUID (toJsonString medReq.supply)) REF=(concat 'Patient/' patientId.Id)}},
-                                {{/with}}
-                                {{>References/MedicationRequest/medicationReference.hbs ID=(generateUUID (toJsonString medReq.supply)) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial)))}},
-                            {{/if}}
-                            {{!-- I am keeping what was originally here but I have yet to see an author placed here --}}
-                            {{#if medReq.supply.author.assignedAuthor}}
-                                {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=medReq.supply.author.assignedAuthor) as |practitionerId|}}
-                                    {{>Resources/Practitioner.hbs practitioner=medReq.supply.author.assignedAuthor ID=practitionerId.Id}},
-                                    {{>References/MedicationRequest/requester.hbs ID=(generateUUID (toJsonString medReq.supply)) REF=(concat 'Practitioner/' practitionerId.Id)}}
-                                {{/with}}
-                                {{#if medReq.supply.author.assignedAuthor.representedOrganization}}
-                                    {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=medReq.supply.author.assignedAuthor.representedOrganization) as |orgId|}}
-                                        {{>Resources/Organization.hbs org=medReq.supply.author.assignedAuthor.representedOrganization ID=orgId.Id}},
-                                        {{>References/MedicationRequest/requester.hbs ID=(generateUUID (toJsonString medReq.supply)) REF=(concat 'Organization/' orgId.Id)}}
+                        {{#with (buildMedicationRequestId (toArray medEntry.substanceAdministration.entryRelationship)) as |medReqId|}} 
+                            {{#each (toArray medEntry.substanceAdministration.entryRelationship) as |medReq|}}
+                                {{#if medReq.supply}}   
+                                    {{>Resources/MedicationRequest.hbs medicationRequest=medReq.supply date=medEntry.substanceAdministration.effectiveTime ID=(medReqId)}},
+                                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                                        {{>References/MedicationRequest/subject.hbs ID=(medReqId) REF=(concat 'Patient/' patientId.Id)}},
                                     {{/with}}
+                                    {{>References/MedicationRequest/medicationReference.hbs ID=(medReqId) REF=(concat 'Medication/' (generateUUID (toJsonString medEntry.substanceAdministration.consumable.manufacturedProduct.manufacturedMaterial)))}},
                                 {{/if}}
-                            {{else if (and medReq.supply medEntry.substanceAdministration.author.assignedAuthor)}}
-                                {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=medEntry.substanceAdministration.author.assignedAuthor) as |practitionerId|}}
-                                    {{>Resources/Practitioner.hbs practitioner=medEntry.substanceAdministration.author.assignedAuthor ID=practitionerId.Id}},
-                                    {{>References/MedicationRequest/requester.hbs ID=(generateUUID (toJsonString medReq.supply)) REF=(concat 'Practitioner/' practitionerId.Id)}}
-                                {{/with}}
-                                {{#if medEntry.substanceAdministration.author.assignedAuthor.representedOrganization}}
-                                    {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=medEntry.substanceAdministration.author.assignedAuthor.representedOrganization) as |orgId|}}
-                                        {{>Resources/Organization.hbs org=medEntry.substanceAdministration.author.assignedAuthor.representedOrganization ID=orgId.Id}},
-                                        {{>References/MedicationRequest/requester.hbs ID=(generateUUID (toJsonString medReq.supply)) REF=(concat 'Organization/' orgId.Id)}}
+                                {{!-- I am keeping what was originally here but I have yet to see an author placed here --}}
+                                {{#if medReq.supply.author.assignedAuthor}}
+                                    {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=medReq.supply.author.assignedAuthor) as |practitionerId|}}
+                                        {{>Resources/Practitioner.hbs practitioner=medReq.supply.author.assignedAuthor ID=practitionerId.Id}},
+                                        {{>References/MedicationRequest/requester.hbs ID=(medReqId) REF=(concat 'Practitioner/' practitionerId.Id)}}
                                     {{/with}}
+                                    {{#if medReq.supply.author.assignedAuthor.representedOrganization}}
+                                        {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=medReq.supply.author.assignedAuthor.representedOrganization) as |orgId|}}
+                                            {{>Resources/Organization.hbs org=medReq.supply.author.assignedAuthor.representedOrganization ID=orgId.Id}},
+                                            {{>References/MedicationRequest/requester.hbs ID=(medReqId) REF=(concat 'Organization/' orgId.Id)}}
+                                        {{/with}}
+                                    {{/if}}
+                                {{else if (and medReq.supply medEntry.substanceAdministration.author.assignedAuthor)}}
+                                    {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=medEntry.substanceAdministration.author.assignedAuthor) as |practitionerId|}}
+                                        {{>Resources/Practitioner.hbs practitioner=medEntry.substanceAdministration.author.assignedAuthor ID=practitionerId.Id}},
+                                        {{>References/MedicationRequest/requester.hbs ID=(medReqId) REF=(concat 'Practitioner/' practitionerId.Id)}}
+                                    {{/with}}
+                                    {{#if medEntry.substanceAdministration.author.assignedAuthor.representedOrganization}}
+                                        {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=medEntry.substanceAdministration.author.assignedAuthor.representedOrganization) as |orgId|}}
+                                            {{>Resources/Organization.hbs org=medEntry.substanceAdministration.author.assignedAuthor.representedOrganization ID=orgId.Id}},
+                                            {{>References/MedicationRequest/requester.hbs ID=(medReqId) REF=(concat 'Organization/' orgId.Id)}}
+                                        {{/with}}
+                                    {{/if}}
                                 {{/if}}
-                            {{/if}}
-
-                        {{/each}}
+                            {{/each}}
+                            {{#with (getSpecifiedEntryRelationshipArray medEntry.substanceAdministration.entryRelationship "RSON") as |reasonEntries|}}
+                                {{#each reasonEntries as |reasonEntry|}}
+                                    {{>Resources/Condition.hbs conditionEntry=reasonEntry.observation ID=(generateUUID (toJsonString reasonEntry.observation))}},
+                                    {{>References/MedicationRequest/reasonReference.hbs ID=(medReqId) REF=(concat 'Condition/' (generateUUID (toJsonString reasonEntry.observation)))}},
+                                {{/each}}
+                            {{/with}}
+                        {{/with}}
                     {{/if}}
 
                     {{#if medEntry.substanceAdministration.informant.assignedEntity.representedOrganization.name._}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Notes.hbs
@@ -33,7 +33,10 @@
                     {{#with (extractTextFromNestedProperties noteText) as |extractedText|}}
                         {{#with (buildDefaultDiagReportDetails notesSection) as |noteAct|}}
                             {{>Resources/DiagnosticReport.hbs diagReport=noteAct categoryCode=notesSection.code ID=(generateUUID (toJsonString noteText))}}
-                            {{>References/DiagnosticReport/assessment.hbs text=extractedText ID=(generateUUID (toJsonString noteText))}}
+                            {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                                {{>References/DiagnosticReport/subject.hbs ID=(generateUUID (toJsonString noteText)) REF=(concat 'Patient/' patientId.Id)}},
+                            {{/with}}
+                            {{>References/DiagnosticReport/assessment.hbs diagReport=noteAct text=extractedText ID=(generateUUID (toJsonString noteText))}}
                             {{#if @encompassingEncounterIds}} 
                                 {{>References/DiagnosticReport/encounter.hbs diagReport=noteAct ID=(generateUUID (toJsonString noteText)) REF=(concat 'Encounter/' @encompassingEncounterIds.newId)}}
                             {{/if}}
@@ -66,7 +69,7 @@
                     {{/if}}   
                     
                     {{#if noteEntry.act.text}} 
-                        {{>References/DiagnosticReport/assessment.hbs text=(extractTextFromNestedProperties noteEntry.act.text) ID=(generateUUID (toJsonString noteEntry.act))}}
+                        {{>References/DiagnosticReport/assessment.hbs diagReport=noteEntry.act text=(extractTextFromNestedProperties noteEntry.act.text) ID=(generateUUID (toJsonString noteEntry.act))}}
                     {{/if}}
 
                 {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Problems.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Problems.hbs
@@ -29,7 +29,7 @@
         {{#each (multipleToArray 2_16_840_1_113883_10_20_22_2_5_1.entry 2_16_840_1_113883_10_20_22_2_5.entry) as |problems|}}
             {{#each (toArray problems.act.entryRelationship) as |condEntry|}}
                 {{#if condEntry.observation}}
-                    {{>Resources/Condition.hbs conditionEntry=condEntry.observation ID=(generateUUID (toJsonString condEntry.observation))}},
+                    {{>Resources/Condition.hbs conditionEntry=condEntry.observation encounterDate=problems.act.effectiveTime ID=(generateUUID (toJsonString condEntry.observation))}},
                     {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                         {{>References/Condition/subject.hbs ID=(generateUUID (toJsonString condEntry.observation)) REF=(concat 'Patient/' patientId.Id)}},
                     {{/with}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Procedures.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Procedures.hbs
@@ -47,7 +47,6 @@
                             {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString procEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}},
                         {{/with}}
                     {{/if}}
-                    {{!-- TODO: Look into adding report --}}
                 {{/if}}
                 
                 {{#if procEntry.observation}}
@@ -58,12 +57,15 @@
 
                     {{#if procEntry.observation.value}}
                         {{>Resources/DiagnosticReport.hbs diagReport=procEntry.observation categoryCode=procSection.code ID=(generateUUID (toJsonString procEntry.observation.value))}}
+                        {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+                            {{>References/DiagnosticReport/subject.hbs ID=(generateUUID (toJsonString procEntry.observation.value)) REF=(concat 'Patient/' patientId.Id)}},
+                        {{/with}}
                         {{>References/Procedure/report.hbs ID=(generateUUID (toJsonString procEntry.observation)) REF=(concat 'DiagnosticReport/' (generateUUID (toJsonString procEntry.observation.value)))}}
                     {{/if}}
                     
                     {{#if procEntry.observation.author.assignedAuthor}}
                         {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=procEntry.observation.author.assignedAuthor) as |practitionerId|}}
-                                {{>Resources/Practitioner.hbs practitioner=procEntry.procedure.observation.author.assignedAuthor ID=practitionerId.Id}},
+                                {{>Resources/Practitioner.hbs practitioner=procEntry.observation.author.assignedAuthor ID=practitionerId.Id}},
                                 {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString procEntry.observation)) REF=(concat 'Practitioner/' practitionerId.Id)}},
                         {{/with}}
                     {{/if}}

--- a/packages/fhir-converter/src/templates/cda/Sections/ReasonforReferral.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/ReasonforReferral.hbs
@@ -32,12 +32,18 @@
                 {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=referralEntry.act.author.assignedAuthor) as |practitionerId|}}
                     {{>Resources/Practitioner.hbs practitioner=referralEntry.act.author.assignedAuthor ID=practitionerId.Id}},
                     {{>References/ServiceRequest/requester.hbs ID=(generateUUID (toJsonString referralEntry.act)) REF=(concat 'Practitioner/' practitionerId.Id)}},
+                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+	                    {{>References/ServiceRequest/subject.hbs ID=(generateUUID (toJsonString referralEntry.act)) REF=(concat 'Patient/' patientId.Id)}},
+                    {{/with}}
                 {{/with}}
             {{/if}}
             {{#if referralEntry.act.author.assignedAuthor.representedOrganization}}
                 {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=referralEntry.act.author.assignedAuthor.representedOrganization) as |orgId|}}
                     {{>Resources/Organization.hbs org=referralEntry.act.author.assignedAuthor.representedOrganization ID=orgId.Id}},
                     {{>References/ServiceRequest/requester.hbs ID=(generateUUID (toJsonString referralEntry.act)) REF=(concat 'Organization/' orgId.Id)}},
+                    {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
+	                    {{>References/ServiceRequest/subject.hbs ID=(generateUUID (toJsonString referralEntry.act)) REF=(concat 'Patient/' patientId.Id)}},
+                    {{/with}}
                 {{/with}}
             {{/if}}
     {{/each}}

--- a/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
+++ b/packages/fhir-converter/src/templates/cda/Sections/Results.hbs
@@ -65,7 +65,6 @@
                             {{/if}}
                         {{/if}}
                     {{/if}}
-
                     {{#each (toArray drEntry.organizer.component) as |obsEntry|}}
                         {{#if obsEntry.observation}}
                             {{#if (not obsEntry.observation.value._b64)}}
@@ -104,13 +103,12 @@
                             {{>Resources/Procedure.hbs procedureEntry=obsEntry.procedure ID=(generateUUID (toJsonString obsEntry.procedure))}}
                             {{#with (evaluate 'Utils/GeneratePatientId.hbs' obj=@metriportPatientId) as |patientId|}}
                                 {{>References/Procedure/subject.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Patient/' patientId.Id)}},
+                                {{>References/Procedure/report.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'DiagnosticReport/' (generateUUID (toJsonString drEntry.organizer)))}}
                             {{/with}}
-
                             {{#if drEntry.organizer.performer.assignedEntity}}
                                 {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=drEntry.organizer.performer.assignedEntity) as |practitionerId|}}
                                     {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}}
                                 {{/with}}
-
                                 {{#if drEntry.organizer.performer.assignedEntity.representedOrganization}}
                                     {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=drEntry.organizer.performer.assignedEntity.representedOrganization) as |orgId|}}
                                         {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Organization/' orgId.Id)}},
@@ -120,7 +118,6 @@
                                 {{#with (evaluate 'Utils/GeneratePractitionerId.hbs' obj=drEntry.organizer.author.assignedAuthor) as |practitionerId|}}
                                     {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Practitioner/' practitionerId.Id)}},
                                 {{/with}}
-
                                 {{#if drEntry.organizer.author.assignedAuthor.representedOrganization}}
                                     {{#with (evaluate 'Utils/GenerateOrganizationId.hbs' obj=drEntry.organizer.author.assignedAuthor.representedOrganization) as |orgId|}}
                                         {{>References/Procedure/performer.actor.hbs ID=(generateUUID (toJsonString obsEntry.procedure)) REF=(concat 'Organization/' orgId.Id)}},

--- a/packages/fhir-converter/src/templates/cda/Utils/PeriodOrDefaultPeriod.hbs
+++ b/packages/fhir-converter/src/templates/cda/Utils/PeriodOrDefaultPeriod.hbs
@@ -24,7 +24,7 @@
   //     CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  
   // -------------------------------------------------------------------------------------------------
 --}}
-{{#if (nullFlavorAwareOr period.low period.high)}}
+{{#if (or (nullFlavorAwareOr period.low period.high) (nullFlavorAwareOr period.value))}}
     {{>DataType/Period.hbs period=period}}
 {{else}}
     {{>DataType/Period.hbs period=@encounterTimePeriod}}


### PR DESCRIPTION
## Summary
- Updates packages/fhir-converter from upstream Metriport commit c6751a33ac5dc7aae18a041dca42e14a5a482111.
- Preserves Fasten-specific Docker/GHCR behavior.
- Leaves fasten-connect-api behavior unchanged.

## Validation
- docker buildx build --platform linux/amd64 --load -t ghcr.io/fastenhealth/metriport:c6751a33 -t ghcr.io/fastenhealth/metriport:latest packages/fhir-converter
- Five sample C-CDAs returned HTTP 200 with fhirResource.resourceType === Bundle.
- The two Chunli Myra samples did not fail with the toString TypeError.
- npm test passed: 8 suites, 111 tests.